### PR TITLE
bionic-jenkins-slave image support

### DIFF
--- a/images/bionic-jenkins-slave.json
+++ b/images/bionic-jenkins-slave.json
@@ -1,0 +1,31 @@
+{
+    "builders": [
+        {
+            "type": "openstack",
+            "source_image_name": "Ubuntu 18.04",
+            "ssh_username": "ubuntu",
+            "openstack_provider": "nova",
+            "image_name": "bionic-jenkins-slave",
+            "ssh_ip_version": "6",
+            "flavor": "1"
+        }
+    ],
+    "provisioners": [
+        {
+            "type": "shell",
+            "script": "scripts/ubuntu/common.sh"
+        },
+        {
+            "type": "shell",
+            "script": "scripts/ubuntu/docker.sh"
+        },
+        {
+            "type": "shell",
+            "script": "scripts/ubuntu/packer.sh"
+        },
+        {
+            "type": "shell",
+            "script": "scripts/ubuntu/novaclient.sh"
+        }
+    ]
+}


### PR DESCRIPTION
Ubuntu 18.04 is significantly newer. In particular, we're hoping that
the kernel available there will give us fewer issues with docker
overlay support, as observed in issues like:

https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1659417

and

https://github.com/docker/docker/issues/28391